### PR TITLE
Fixes #18 : scrolling works with the cursor + space between scollbar and text

### DIFF
--- a/rebound/rebound.py
+++ b/rebound/rebound.py
@@ -699,7 +699,7 @@ class App(object):
 
                 pile = urwid.Pile(self._stylize_question(question_title, question_desc, question_stats) + [urwid.Divider('*')] +
                 interleave(answers, [urwid.Divider('-')] * (len(answers) - 1)))
-                padding = urwid.Padding(ScrollBar(Scrollable(pile)), left=2, right=2)
+                padding = urwid.Padding(ScrollBar(Scrollable(urwid.Padding(pile, left=0, right=2))), left=2, right=0)
                 #filler = urwid.Filler(padding, valign="top")
                 linebox = urwid.LineBox(padding)
 

--- a/rebound/rebound.py
+++ b/rebound/rebound.py
@@ -509,6 +509,7 @@ class ScrollBar(urwid.WidgetDecoration):
         self.scrollbar_side = side
         self.scrollbar_width = max(1, width)
         self._original_widget_size = (0, 0)
+        self._dragging = False
 
 
     def render(self, size, focus=False):
@@ -629,6 +630,16 @@ class ScrollBar(urwid.WidgetDecoration):
                 return True
             elif col == self.scrollbar_column:
                 ow.set_scrollpos(int(row*ow.scroll_ratio))
+                if event == "mouse press":
+                    self._dragging = True
+                elif event == "mouse release":
+                    self._dragging = False
+            elif self._dragging:
+                ow.set_scrollpos(int(row*ow.scroll_ratio))
+                if event == "mouse release":
+                    self._dragging = False
+
+
 
         return False
 

--- a/rebound/rebound.py
+++ b/rebound/rebound.py
@@ -699,7 +699,7 @@ class App(object):
 
                 pile = urwid.Pile(self._stylize_question(question_title, question_desc, question_stats) + [urwid.Divider('*')] +
                 interleave(answers, [urwid.Divider('-')] * (len(answers) - 1)))
-                padding = urwid.Padding(ScrollBar(Scrollable(urwid.Padding(pile, left=0, right=2))), left=2, right=0)
+                padding = ScrollBar(Scrollable(urwid.Padding(pile, left=2, right=2)))
                 #filler = urwid.Filler(padding, valign="top")
                 linebox = urwid.LineBox(padding)
 


### PR DESCRIPTION
This allows to click to move the scrollbar or to drag the scrollbar with the cursor.
I check first if the click is happening in the scrollbars column, defined as its parents rightmost or leftmost column depending on where the scrollbar is placed.