### PR TITLE
Fix upward scrolling bug when using scroll wheel

### DIFF
--- a/rebound/rebound.py
+++ b/rebound/rebound.py
@@ -611,8 +611,9 @@ class ScrollBar(urwid.WidgetDecoration):
         if not handled and hasattr(ow, "set_scrollpos"):
             if button == 4: # Scroll wheel up
                 pos = ow.get_scrollpos(ow_size)
-                ow.set_scrollpos(pos - 1)
-                return True
+                if pos > 0:
+                    ow.set_scrollpos(pos - 1)
+                    return True
             elif button == 5: # Scroll wheel down
                 pos = ow.get_scrollpos(ow_size)
                 ow.set_scrollpos(pos + 1)


### PR DESCRIPTION
After selecting a Stack Overflow link, if the scroll bar is at the
top of the page, scrolling upwards using the scroll wheel causes the
scroll bar to move to the bottom of the page instead of staying at
the top of the page.

This was fixed by adding a check to the scroll wheel up mouse event
and only doing ow.set_scrollpos(pos - 1) if pos > 0.