### PR TITLE
Add error handling for Stack Overflow get request

### DIFF
--- a/rebound/rebound.py
+++ b/rebound/rebound.py
@@ -276,7 +276,13 @@ def get_search_results(soup):
 
 def souper(url):
     """Turns a given URL into a BeautifulSoup object."""
-    html = requests.get(url, headers={"User-Agent": random.choice(USER_AGENTS)})
+
+    try:
+        html = requests.get(url, headers={"User-Agent": random.choice(USER_AGENTS)})
+    except requests.exceptions.RequestException:
+        sys.stdout.write("\n%s%s%s" % (RED, "Rebound was unable to fetch Stack Overflow results. "
+                                            "Please check that you are connected to the internet.\n", END))
+        sys.exit(1)
 
     if re.search("\.com/nocaptcha", html.url): # URL is a captcha page
         return None


### PR DESCRIPTION
Currently there is no error handling for the Stack Overflow get
request in the souper function. If the requests.get function throws
an exception rebound just crashes.

Changed this by putting the requests.get call in a try except block
and adding a friendly error message if the requests.get call throws
an exception.