### PR TITLE
added "search" and "commandline" to keywords

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python"
     ],
-    keywords="stackoverflow stack overflow debug debugging error-handling compile errors error message cli",
+    keywords="stackoverflow stack overflow debug debugging error-handling compile errors error message cli search commandline",
     include_package_data=True,
     packages=["rebound"],
     entry_points={"console_scripts": ["rebound = rebound.rebound:main"]},


### PR DESCRIPTION
Added the words "search " and "commandline" to keywords in setup.py. Rebound offers a search functionality and it would be very nice to add "search" which is one of its core functionality to keywords.