### PR TITLE
Add unit tests for Python

### DIFF
--- a/rebound/rebound.py
+++ b/rebound/rebound.py
@@ -115,7 +115,7 @@ def get_error_message(error, language):
         if any(e in error for e in ["KeyboardInterrupt", "SystemExit", "GeneratorExit"]): # Non-compiler errors
             return None
         else:
-            return error.split('\n')[-2][1:]
+            return error.split('\n')[-2].strip()
     elif language == "node":
         return error.split('\n')[4][1:]
     elif language == "go run":

--- a/tests/python_test.py
+++ b/tests/python_test.py
@@ -1,0 +1,46 @@
+import pytest
+import traceback
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname( __file__ ), "..", "rebound"))
+import rebound
+
+# Constants and helper functions
+EXCEPTION_DETAILS = "Exception details"
+
+def gen_python_exception(exception_type):
+    stack_trace = None
+    try:
+        raise exception_type(EXCEPTION_DETAILS)
+    except Exception:
+        stack_trace = traceback.format_exc()
+    return stack_trace
+
+def gen_expected_message(exception_type_str):
+    return exception_type_str + ": " + EXCEPTION_DETAILS
+
+# Tests
+@pytest.mark.parametrize("exception_type, exception_type_str", [
+    (StopIteration, "StopIteration"),
+    (StopAsyncIteration, "StopAsyncIteration"),
+    (ArithmeticError, "ArithmeticError"),
+    (AssertionError, "AssertionError"),
+    (AttributeError, "AttributeError"),
+    (BufferError, "BufferError"),
+    (EOFError, "EOFError"),
+    (ImportError, "ImportError"),
+    (MemoryError, "MemoryError"),
+    (NameError, "NameError"),
+    (OSError, "OSError"),
+    (ReferenceError, "ReferenceError"),
+    (RuntimeError, "RuntimeError"),
+    (SyntaxError, "SyntaxError"),
+    (SystemError, "SystemError"),
+    (TypeError, "TypeError"),
+    (ValueError, "ValueError"),
+    (Warning, "Warning")
+])
+def test_get_error_message(exception_type, exception_type_str):
+    error_message = rebound.get_error_message(gen_python_exception(exception_type), "python3")
+    expected_error_message = gen_expected_message(exception_type_str)
+    assert error_message == expected_error_message


### PR DESCRIPTION
Added unit tests to make sure the get_error_message function is
correctly pulling error messages from Python exception stack traces.

Changed the get_error_message function so that for pulling the error
message from the Python stack trace, the strip function is used
instead of using array slicing to remove whitespace.